### PR TITLE
fix bug on issues #1

### DIFF
--- a/src/sm2/sm2.js
+++ b/src/sm2/sm2.js
@@ -57,7 +57,7 @@ class SM2Cipher {
             if (this.keyOff === this.key.length) {
                 this.nextKey();
             }
-            data[i] ^= this.key[this.keyOff++];
+            data[i] ^= this.key[this.keyOff++] & 0xff;
         }
     }
 
@@ -71,7 +71,7 @@ class SM2Cipher {
             if (this.keyOff === this.key.length) {
                 this.nextKey();
             }
-            data[i] ^= this.key[this.keyOff++];
+            data[i] ^= this.key[this.keyOff++] & 0xff;
         }
         this.sm3c3.blockUpdate(data, 0, data.length);
     }


### PR DESCRIPTION
修复issues#1，sm2加解密偶现的失败是因为key数组中出现了大于255的元素(元素256应该是0)，因此需要&0xff
Fix issues #1,  the failure of sm2 is because there are some elements bigger than 255 in the key array, so &0xff is required.